### PR TITLE
Git mailmap support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gitcount

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ FROM scratch
 
 VOLUME ["/repo"]
 
-COPY --from=temp /bin/gitcount /bin/gitcount
-COPY --from=temp /etc/passwd /etc/passwd
+COPY --from=builder /bin/gitcount /bin/gitcount
+COPY --from=builder /etc/passwd /etc/passwd
 
 USER appuser
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 GIT_HASH	?= $(shell git rev-parse --short HEAD)
 NAMESPACE	?= gitcount
 REPOSITORY	?= $(shell basename -s .git `git config --get remote.origin.url`)
-LABEL		?= 0.0.1
+LABEL		?= 0.0.2
 BASENAME	?= ${REPOSITORY}:${LABEL}
 LATEST		?= ${REPOSITORY}:latest
 
@@ -17,7 +17,7 @@ push:
     docker push ${NAMESPACE}\/${BASENAME} 
 
 info:
-    @echo "GIT Hash:	${GIT_HASH}"
+    @echo "GIT Hash:	        ${GIT_HASH}"
     @echo "Docker Namespace:	${NAMESPACE}"
     @echo "Docker Repository:	${REPOSITORY}"
     @echo "Docker Label:		${LABEL}"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Total: 19.86 hours
 
 ## Example using Docker
 ```sh
-$ docker run --rm -it -v `pwd`:/repo gitcount/gitcount:0.0.1
+$ docker run --rm -it -v `pwd`:/repo gitcount/gitcount:0.0.2
 Project root: /repo
 mail@ferdinand-muetsch.de: 1.73 hours
 noreply@github.com: 0.65 hours

--- a/mailmap.go
+++ b/mailmap.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// ReadMailMap reads a .mailmap file and returns the relation mapped amongst the emails.
+func ReadMailMap(reader io.Reader) (map[string]*MailMapEntry, error) {
+	if reader == nil {
+		return nil, nil
+	}
+
+	mailmap := make(map[string]*MailMapEntry)
+	scanner := bufio.NewScanner(reader)
+	utf8bom := []byte{0xEF, 0xBB, 0xBF} //UTF8 Byte order mark
+
+	// Regular Expression to extract the fields required. Only uses proper email and commit email
+	pattern := regexp.MustCompile(`^(?P<pname>[^<]+)?(?:\\s+)?(?:<(?P<pmail>.*?)>)?(?:\\s+)?(?P<cname>[^<]+)?(?:\\s+)?(?:<(?P<cmail>.*?)>)?$`)
+
+	currentLine := 0
+	for scanner.Scan() {
+		scannedBytes := scanner.Bytes()
+		if currentLine == 0 {
+			scannedBytes = bytes.TrimPrefix(scannedBytes, utf8bom)
+		}
+		currentLine++
+		row := string(scannedBytes)
+		if strings.HasPrefix(row, "#") {
+			continue
+		}
+		if row := strings.TrimSpace(row); row == "" {
+			continue
+		}
+
+		groups := pattern.FindStringSubmatch(row)
+		entry := MailMapEntry{groups[2], groups[4]}
+
+		if _, hasKey := mailmap[entry.CommitEmail]; !hasKey {
+			mailmap[entry.CommitEmail] = &entry
+		}
+		if _, hasKey := mailmap[entry.ProperEmail]; !hasKey {
+			mailmap[entry.ProperEmail] = &entry
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("Error reading .mailmap: %v", err)
+	}
+	return mailmap, nil
+}

--- a/model.go
+++ b/model.go
@@ -13,6 +13,11 @@ type CommitSummary struct {
 
 type CommitList []*CommitSummary
 
+type MailMapEntry struct {
+	ProperEmail string
+	CommitEmail string
+}
+
 func (l CommitList) Len() int {
 	return len(l)
 }


### PR DESCRIPTION
Added suport to git check mailmap (https://git-scm.com/docs/git-check-mailmap)

## Changelog :memo:

1. Added `mailmap.go` this file handle the read and serialization needed to properly map email and alias;
2. Edited `main.go` Changed the spots needed to use the proper email configured on `.mailmap`;
3. Fixed `Dockerfile` I was referring to a cached layer (`temp`) only on my machine, fix to the correct one (`builder` earlier stage);

## Comparison:

#### Before:
```sh
$ docker run --rm -it -v `pwd`:/repo gitcount/gitcount:0.0.1
Project root: /repo
felipe.espitalher@gmail.com: 109.53 hours
gonzalesraul03@gmail.com: 105.46 hours
tiagocunha@gmail.com: 73.45 hours
daniel.nascimento@schoolastic-app.com: 36.87 hours
daniel.nascimento@youmobi.com.br: 26.42 hours
felipe.passos@iwsbrazil.com: 4.75 hours
fpassos@MacBook-Pro-de-Felipe.local: 0.96 hours
---------
Total: 357.45 hours
```
#### After
```sh
$ docker run --rm -it -v `pwd`:/repo gitcount/gitcount:0.0.2
Project root: /repo
felipe.espitalher@gmail.com: 115.24 hours
gonzalesraul03@gmail.com: 105.46 hours
tiagocunha@gmail.com: 73.45 hours
daniel.nascimento@schoolastic-app.com: 63.30 hours
---------
Total: 357.45 hours
```
------------------------
Closes: #4 Alias multiple emails to a single user
